### PR TITLE
Add customizable variable for arguments to yamllint

### DIFF
--- a/flymake-yamllint.el
+++ b/flymake-yamllint.el
@@ -52,6 +52,11 @@
   "Name of `yamllint' executable."
   :type 'string)
 
+(defcustom flymake-yamllint-arguments
+  nil
+  "A list of strings to pass to the yamllint program as arguments."
+  :type '(repeat (string :tag "Argument")))
+
 (defvar-local flymake-yamllint--proc nil)
 
 (defun flymake-yamllint (report-fn &rest _args)
@@ -73,7 +78,7 @@
          (make-process
           :name "flymake-yamllint" :noquery t :connection-type 'pipe
           :buffer (generate-new-buffer " *flymake-yamllint*")
-          :command (list flymake-yamllint--executable-path "-" "-f" "parsable")
+          :command `(,flymake-yamllint--executable-path ,@flymake-yamllint-arguments "-f" "parsable" "-")
           :sentinel
           (lambda (proc _event)
             (when (eq 'exit (process-status proc))


### PR DESCRIPTION
This allows to launch yamllint through some other program that requires additional arguments, such as Podman or Make, or adding e.g. the "--strict" argument to yamllint.

In my case, I wanted to be able to do something like this in a `.dir-locals.el`:

```emacs-lisp
((yaml-mode . ((flymake-yamllint-program . "podman")
               (flymake-yamllint-arguments . ("run"
                                              "--rm"
                                              "--interactive"
                                              "docker.io/cytopia/yamllint")))))
```